### PR TITLE
git_revwalk_next: handle `GIT_ITEROVER`

### DIFF
--- a/libgit2/include/pack.rkt
+++ b/libgit2/include/pack.rkt
@@ -5,7 +5,8 @@
          (only-in "types.rkt"
                   _git_repository
                   _git_transfer_progress_cb
-                  _git_packbuilder
+                  _git_packbuilder)
+         (only-in "revwalk.rkt"
                   _git_revwalk)
          "../private/buffer.rkt"
          "../private/base.rkt")

--- a/libgit2/include/revwalk.rkt
+++ b/libgit2/include/revwalk.rkt
@@ -3,12 +3,14 @@
 (require ffi/unsafe
          (submod "oid.rkt" private)
          (only-in "types.rkt"
-                  _git_repository
-                  _git_revwalk)
+                  _git_repository)
          "../private/base.rkt")
 
 (provide (all-defined-out))
+
 ; Types
+
+(define-cpointer-type _git_revwalk)
 
 (define _git_sort_t
   (_bitmask '(GIT_SORT_NONE = 0
@@ -43,8 +45,13 @@
   (_fun _git_revwalk _git_repository -> _int)
   git_revwalk_free)
 
-(define-libgit2/check git_revwalk_next
-  (_fun _git_oid-pointer _git_revwalk -> _int))
+(define-libgit2 git_revwalk_next
+  (_fun [oid : (_ptr o _git_oid)]
+        _git_revwalk
+        -> [code : (_git_error_code/check #:handle '(GIT_ITEROVER))]
+        -> (if (eq? code 'GIT_ITEROVER)
+               #f
+               oid)))
 
 (define-libgit2/check git_revwalk_push
   (_fun _git_revwalk _git_oid-pointer -> _int))

--- a/libgit2/include/types.rkt
+++ b/libgit2/include/types.rkt
@@ -21,7 +21,6 @@
          git_repository?
          _git_object
          _git_object/null
-         _git_revwalk
          _git_tag
          _git_blob
          _git_blob/null
@@ -98,7 +97,7 @@
 (define-cpointer-type _git_repository)
 ;; not here: _git_worktree
 (define-cpointer-type _git_object)
-(define-cpointer-type _git_revwalk)
+;; moved _git_revwalk to "revwalk.rkt"
 (define-cpointer-type _git_tag)
 (define-cpointer-type _git_blob)
 (define-cpointer-type _git_commit)
@@ -222,16 +221,3 @@
 (define-cpointer-type _git_diff)
 (define-cpointer-type _git_merge_result)
 (define-cpointer-type _git_patch)
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
It is not an error: it signals the end of the walk.

Also, move `_git_revwalk` to `revwalk.rkt` and allocate the output `_git_oid` for the user.

Reported by @kengruven

Related to https://github.com/bbusching/libgit2/issues/11